### PR TITLE
Upgrade coffeescript version and libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "node": "~0.6.10 || 0.8 || 0.9"
   },
   "dependencies": {
-    "coffee-script": "1.3.3"
+    "coffee-script": "1.9.1"
   },
   "devDependencies": {
-    "mocha": "1.2.2",
-    "chai": "1.1.0"
+    "mocha": "2.2.4",
+    "chai": "2.2.0"
   }
 }


### PR DESCRIPTION
Upgrade coffeescript version to a release that works with both nodejs v0.10.x and v0.12.x.
Using coffeescript v1.3.3 with node v0.12.x results in the following error:

> static-html-brunch@1.0.0 postinstall ./static-html-brunch
> node setup.js postinstall
> 
> static-html-brunch@1.0.0 prepublish ./static-html-brunch
> coffee -o lib/ src/

TypeError: undefined is not a function
    at writeJs (./static-html-brunch/node_modules/coffee-script/lib/coffee-script/command.js:413:17)
    at compileScript (./static-html-brunch/node_modules/coffee-script/lib/coffee-script/command.js:185:18)
    at ./static-html-brunch/node_modules/coffee-script/lib/coffee-script/command.js:150:18
    at fs.js:334:14
    at FSReqWrap.oncomplete (fs.js:95:15)

coffeescript v1.3.3 uses path.exists which has been deprecated and removed.
New version uses fs.exists which works in both node versions.
